### PR TITLE
[feat] 프로필 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,14 +49,37 @@ const App = () => {
   );
 };
 
-// ProfilePageWrapper: userId와 로컬 유저 ID 비교 후 마이페이지 여부 설정
+// ProfilePageWrapper: userId를 URL에서 가져와 해당 유저의 프로필 페이지로 이동
 const ProfilePageWrapper = ({ user }) => {
-  const { userId } = useParams(); // URL의 유저 ID 가져오기
-  const isMyPage = userId === user._id; // 유저 ID가 로컬 유저 ID와 같으면 true
+  const { userId } = useParams(); // URL에서 유저 ID 가져오기
 
-  return <ProfilePage user={user} isMyPage={isMyPage} />;
+  // 여기서 실제로 해당 userId에 맞는 유저 정보를 가져옵니다.
+  // 예시로, `fetchUserData`는 서버에서 유저 데이터를 가져오는 함수입니다.
+  const [userData, setUserData] = useState(null);
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        // 예시: 해당 userId로 API 호출하여 유저 데이터 가져오기
+        const response = await fetch(`/api/users/${userId}`);
+        const data = await response.json();
+        setUserData(data);
+      } catch (error) {
+        console.error('유저 데이터 불러오기 실패:', error);
+      }
+    };
+
+    fetchUserData(); // 유저 데이터 로드
+  }, [userId]); // userId가 변경될 때마다 호출
+
+  if (!userData) {
+    return <p>유저 정보를 불러오는 중...</p>; // 로딩 상태 처리
+  }
+
+  return <ProfilePage user={userData} />;
 };
 
+export default App;
 
 // Styled Components
 const Container = styled.div`
@@ -78,5 +101,3 @@ const NavLink = styled(Link)`
     background-color: #eee;
   }
 `;
-
-export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,6 +82,7 @@ export default App;
 
 // Styled Components
 const Container = styled.div`
+/* min-width: 700px; */
   padding: 20px;
 `;
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,12 +37,7 @@ const App = () => {
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/postfeed" element={<PostFeed />} />
           {/* 유저 페이지/마이페이지 */}
-          {user && (
-            <>
-              {/* 유저 카드를 클릭해서 이동할 때 /user/:userId 경로 */}
-              <Route path="/user/:userId" element={<ProfilePageWrapper user={user} />} />
-            </>
-          )}
+          <Route path="/user/:userId" element={<ProfilePageWrapper user={user} />} />
         </Routes>
       </Container>
     </Router>
@@ -53,7 +48,7 @@ const ProfilePageWrapper = ({ user }) => {
   const { userId } = useParams(); // URL에서 유저 ID 가져오기
 
   const [userData, setUserData] = useState(null);
-  const isMyPage = userId === user._id; // 로컬 유저 ID와 비교
+  const isMyPage = userId === user?._id; // 로컬 유저 ID와 비교
 
   useEffect(() => {
     const fetchUserData = async () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,23 @@
-import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { BrowserRouter as Router, Routes, Route, Link, useParams } from 'react-router-dom';
 import Signup from './auth/Signup';
 import Login from './auth/Login';
 import Dashboard from './auth/Dashboard';
 import styled from 'styled-components';
 import Navigation from './components/main/Navigation';
 import PostFeed from './pages/PostFeed/PostFeed';
+import ProfilePage from '../src/profile/ProfilePage.jsx';
 
 const App = () => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const storedUser = localStorage.getItem('user');
+    if (storedUser) {
+      setUser(JSON.parse(storedUser));
+    }
+  }, []);
+
   return (
     <Router>
       <div>
@@ -26,54 +36,47 @@ const App = () => {
           <Route path="/signup" element={<Signup />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/postfeed" element={<PostFeed />} />
+          {/* 유저 페이지/마이페이지 */}
+          {user && (
+            <>
+              {/* 유저 카드를 클릭해서 이동할 때 /user/:userId 경로 */}
+              <Route path="/user/:userId" element={<ProfilePageWrapper user={user} />} />
+            </>
+          )}
         </Routes>
       </Container>
     </Router>
   );
 };
 
-export default App;
+// ProfilePageWrapper: userId와 로컬 유저 ID 비교 후 마이페이지 여부 설정
+const ProfilePageWrapper = ({ user }) => {
+  const { userId } = useParams(); // URL의 유저 ID 가져오기
+  const isMyPage = userId === user._id; // 유저 ID가 로컬 유저 ID와 같으면 true
+
+  return <ProfilePage user={user} isMyPage={isMyPage} />;
+};
+
 
 // Styled Components
 const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100vh;
-  margin-top: 50px;
-  /* background-color: #f0f0f0; */
-
-  @media (max-width: 768px) {
-    padding: 20px;
-  }
+  padding: 20px;
 `;
 
 const Nav = styled.nav`
+  display: flex;
+  justify-content: space-around;
   margin-bottom: 20px;
-  margin-top: 50px;
-
-  @media (max-width: 768px) {
-    margin-top: 10px;
-  }
 `;
 
 const NavLink = styled(Link)`
   padding: 10px 20px;
-  margin: 0 10px;
-  background-color: #bf94e4;
-  color: white;
+  color: #333;
   text-decoration: none;
-  border-radius: 5px;
-  font-size: 16px;
-  font-weight: bold;
 
   &:hover {
-    background-color: #d3d3d3;
-  }
-
-  @media (max-width: 768px) {
-    padding: 8px 16px;
-    font-size: 14px;
+    background-color: #eee;
   }
 `;
+
+export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,18 +49,15 @@ const App = () => {
   );
 };
 
-// ProfilePageWrapper: userId를 URL에서 가져와 해당 유저의 프로필 페이지로 이동
 const ProfilePageWrapper = ({ user }) => {
   const { userId } = useParams(); // URL에서 유저 ID 가져오기
 
-  // 여기서 실제로 해당 userId에 맞는 유저 정보를 가져옵니다.
-  // 예시로, `fetchUserData`는 서버에서 유저 데이터를 가져오는 함수입니다.
   const [userData, setUserData] = useState(null);
+  const isMyPage = userId === user._id; // 로컬 유저 ID와 비교
 
   useEffect(() => {
     const fetchUserData = async () => {
       try {
-        // 예시: 해당 userId로 API 호출하여 유저 데이터 가져오기
         const response = await fetch(`/api/users/${userId}`);
         const data = await response.json();
         setUserData(data);
@@ -69,14 +66,16 @@ const ProfilePageWrapper = ({ user }) => {
       }
     };
 
-    fetchUserData(); // 유저 데이터 로드
-  }, [userId]); // userId가 변경될 때마다 호출
+    if (!isMyPage) {  // 마이페이지가 아니라면, 유저 데이터를 불러옵니다.
+      fetchUserData();
+    }
+  }, [userId, isMyPage]);
 
-  if (!userData) {
-    return <p>유저 정보를 불러오는 중...</p>; // 로딩 상태 처리
+  if (!userData && !isMyPage) {
+    return <p>유저 정보를 불러오는 중...</p>;
   }
 
-  return <ProfilePage user={userData} />;
+  return <ProfilePage user={isMyPage ? user : userData} isMyPage={isMyPage} />;
 };
 
 export default App;

--- a/src/components/UserCard.jsx
+++ b/src/components/UserCard.jsx
@@ -4,8 +4,9 @@ import ExampleImage from '../assets/images/default-profile.png';
 import { useNavigate } from 'react-router-dom';
 import { getUsers } from '../utils/api'; 
 
-const UserCard = ({ user, onNavigate }) => {
+const UserCard = ({ user, navigate }) => {
   const { image, fullName, role, _id } = user;
+  // 코멘트가 50자를 넘을 경우 자르고 '...'을 붙임
 
   let nickName = '...';
   let bio = '...';
@@ -15,36 +16,35 @@ const UserCard = ({ user, onNavigate }) => {
     try {
       const parsedFullName = JSON.parse(fullName);
       nickName = parsedFullName.nickName || nickName;
-      bio = parsedFullName.bio || bio;
+      bio = parsedFullName.bio || bio; // bio도 파싱
     } catch (error) {
       console.error('fullName 파싱 오류:', error);
     }
   }
 
   // bio가 50자를 넘으면 자르기
-  const truncatedBio = bio.length > 50 ? bio.slice(0, 50) + '...' : bio;
+  const Introduce = bio.length > 50 ? bio.slice(0, 50) + '...' : bio;
 
   const handleCardClick = () => {
-    onNavigate(`/userpage/${_id}`);
+    navigate(`/user/${_id}`);
   };
 
   return (
-    <StyledCard onClick={handleCardClick}>
-      <StyledProfileImage src={image || ExampleImage} alt={nickName} /> {/* 프로필 이미지 */}
-      <StyledUserInfo>
-        <StyledUserName>{nickName}</StyledUserName> {/* 유저 이름 */}
-        <StyledUserRole>{role}</StyledUserRole> {/* 유저 역할 */}
-        <StyledUserBio>{truncatedBio}</StyledUserBio> {/* 유저 자기소개 */}
-      </StyledUserInfo>
-    </StyledCard>
+    <Card onClick={handleCardClick}>
+      <ProfileImage src={image || ExampleImage} alt={nickName} /> {/* 프로필 이미지 */}
+      <UserInfo>
+        <UserName>{nickName}</UserName> {/* 유저 이름 */}
+        <UserTitle>{role}</UserTitle> {/* 유저 역할 */}
+        <UserBio>{Introduce}</UserBio> {/* 유저 자기소개 */}
+      </UserInfo>
+    </Card>
   );
 };
 
 const App = () => {
   const [users, setUsers] = useState([]);
-  const navigate = useNavigate(); // useNavigate 훅
+  const navigate = useNavigate();
 
-  // API 호출을 통해 유저 데이터 가져오기
   useEffect(() => {
     const fetchUsers = async () => {
       try {
@@ -55,17 +55,17 @@ const App = () => {
       }
     };
 
-    fetchUsers();
+    fetchUsers(); // 유저 데이터 가져오기
   }, []);
 
   return (
     <div>
       <h1>유저 카드 리스트</h1>
-      <StyledUserList>
+      <UserList>
         {users.map((user) => (
-          <UserCard key={user._id} user={user} onNavigate={navigate} />
+          <UserCard key={user._id} user={user} navigate={navigate} /> // navigate 전달
         ))}
-      </StyledUserList>
+      </UserList>
     </div>
   );
 };
@@ -73,38 +73,34 @@ const App = () => {
 export default App;
 
 // Styled Components
-const StyledCard = styled.div`
+const Card = styled.div`
   display: flex;
   align-items: center;
   width: 420px;
   border-radius: 16px;
   padding: 8px;
-
-  &:hover {
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
-  }
 `;
 
-const StyledProfileImage = styled.img`
+const ProfileImage = styled.img`
   width: 80px;
   height: 80px;
   border-radius: 50%;
 `;
 
-const StyledUserInfo = styled.div`
+const UserInfo = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   margin-left: 17px;
 `;
 
-const StyledUserName = styled.h2`
+const UserName = styled.h2`
   font-size: 1em;
   margin: 0;
   color: #333;
 `;
 
-const StyledUserRole = styled.p`
+const UserTitle = styled.p`
   margin: 5px 0;
   display: flex;
   justify-content: center;
@@ -114,10 +110,10 @@ const StyledUserRole = styled.p`
   border-radius: 35px;
   font-size: 12px;
   color: #474150;
-  white-space: nowrap;
+  white-space: nowrap; /* 긴 텍스트가 줄 바꿈되지 않도록 */
 `;
 
-const StyledUserBio = styled.p`
+const UserBio = styled.p`
   margin: 5px 0;
   text-align: left;
   padding: 13px;
@@ -129,7 +125,7 @@ const StyledUserBio = styled.p`
   color: white;
 `;
 
-const StyledUserList = styled.div`
+const UserList = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -20,7 +20,7 @@ const UserProfileCard = ({ user, onNavigate }) => {
   }
 
   const handleCardClick = () => {
-    onNavigate(`/userpage/${_id}`);
+    onNavigate(`/user/${_id}`);
   };
 
   return (

--- a/src/components/main/Navigation.jsx
+++ b/src/components/main/Navigation.jsx
@@ -32,7 +32,7 @@ const Navigation = () => {
   // 프로필 클릭 시 해당 유저 페이지로 이동
   const handleProfileClick = () => {
     if (user && user._id) {
-      navigate(`/userpage/${user._id}`); // 유저의 _id를 기반으로 이동
+      navigate(`/user/${user._id}`); // 유저의 _id를 기반으로 이동
     }
   };
 
@@ -124,10 +124,6 @@ const HeaderContainer = styled.header`
   justify-content: space-between;
   padding: 5px 10px;
   background-color: #f8f9fa;
-
-  @media (max-width: 768px) {
-    align-items: flex-start; /* 왼쪽 정렬 */
-  }
 `;
 
 const Logo = styled.div`
@@ -141,9 +137,6 @@ const Navbar = styled.nav`
   display: flex;
   gap: 20px;
 
-  @media (max-width: 768px) {
-    /* flex-wrap: wrap; 아이템이 많아지면 줄바꿈 */
-  }
 `;
 
 const NavItem = styled.a`
@@ -236,7 +229,7 @@ const ProfileSection = styled.div`
 
   .title {
     display: flex;
-    padding: 10px 30px;
+    padding: 5px 30px;
     background: #ede4db;
     border-radius: 35px;
     font-size: 14px;
@@ -255,10 +248,10 @@ const ProfileSection = styled.div`
     width: 40px;
     height: 40px;
     margin-left: 5px;
+    margin-top: 5px;
   }
 
   img.notification {
-    margin-left: 5px;
     width: 24px;
     height: 24px;
   }

--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { getUserData, fetchPostsByAuthor } from '../utils/api';
 import PostCard from '../components/PostCard';
 import defaultProfileImage from '../assets/images/default-profile.png';
+import ProfileEditModal from '../components/modals/ProfileEditModal';
 
 const ProfilePageWrapper = ({ user, token }) => {
   const { userId } = useParams();
@@ -45,6 +46,8 @@ const ProfilePageWrapper = ({ user, token }) => {
 const ProfilePage = ({ user, isMyPage }) => {
   const [posts, setPosts] = useState([]);
   const [error, setError] = useState(null);
+  const [isEditModalOpen, setEditModalOpen] = useState(false); // 모달 상태 관리
+
 
   useEffect(() => {
     const loadPosts = async () => {
@@ -76,14 +79,19 @@ const ProfilePage = ({ user, isMyPage }) => {
       <Header>
         <ProfileImage src={user?.image || defaultProfileImage} alt="프로필" />
         <ProfileInfo>
+          <ProfileHeader>
           <h2>{userFullName.nickName || '이름 없음'}</h2>
+                          {/* 마이페이지일 때만 수정 버튼 노출 */}
+                    {isMyPage && (
+            <EditButton onClick={() => setEditModalOpen(true)}>✏️ 회원정보 수정</EditButton>
+          )}
+          </ProfileHeader>
           <Role><div>{user.role || '역할 없음'}</div></Role>
           <Bio>
             <p>{userFullName.bio || '자기소개 없음'}</p>
           </Bio>
         </ProfileInfo>
       </Header>
-
       <Content>
         <PostSection>
           <h2>{userFullName.nickName || '이름 없음'}의 추천 포스트</h2>
@@ -103,6 +111,14 @@ const ProfilePage = ({ user, isMyPage }) => {
           <h2>{userFullName.nickName || '이름 없음'}의 음원</h2>
         </MusicSection>
       </Content>
+
+      {/* 모달 창: isEditModalOpen이 true일 때만 보임 */}
+      {isEditModalOpen && (
+        <ProfileEditModal 
+          user={user} 
+          closeModal={() => setEditModalOpen(false)} // 모달 닫기 함수 전달
+        />
+      )}
     </Container>
   );
 };
@@ -136,13 +152,38 @@ const ProfileImage = styled.img`
 
 const ProfileInfo = styled.div`
   align-items: center;
+`;
+const ProfileHeader = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+
   h2 {
     font-size: 1.3rem;
     font-weight: 600;
     margin: 3px 3px;
   }
+
+  /* 닉네임과 회원정보 수정 버튼이 함께 정렬되도록 */
+  position: relative;
 `;
 
+// 회원정보 수정 버튼 스타일
+const EditButton = styled.button`
+  padding: 5px 10px;
+  background-color: transparent; /* 배경색 투명 */
+  color: #808080; /* 글씨색 회색 */
+  border: none;
+  font-size: 0.9rem;
+  cursor: pointer;
+  position: absolute; /* 닉네임에서 떨어지도록 위치 조정 */
+  left: 180px;
+  top: 30px;
+
+  &:hover {
+    color: #a9a9a9; /* hover 시 조금 더 밝은 회색 */
+  }
+`;
 const Role = styled.div`
   text-align: center;
   font-weight: 700;

--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -1,0 +1,124 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import { fetchPostsByAuthor } from '../utils/api';
+import PostCard from '../components/PostCard';
+import defaultProfileImage from '../assets/images/default-profile.png';
+
+const ProfilePageWrapper = ({ user }) => {
+  const { userId } = useParams(); // URL의 유저 ID 가져오기
+  const isMyPage = userId === user._id; // 유저 ID가 로컬 유저 ID와 같으면 true
+
+  return <ProfilePage user={user} isMyPage={isMyPage} />; // ProfilePage 컴포넌트에 user와 isMyPage를 전달
+};
+
+const ProfilePage = ({ user, isMyPage }) => {
+  const [posts, setPosts] = useState([]); // 포스트 목록을 저장할 상태 변수
+  const [error, setError] = useState(null); // 에러 처리 변수
+
+  // 컴포넌트가 마운트될 때 유저의 포스트를 불러오는 useEffect
+  useEffect(() => {
+    const loadPosts = async () => {
+      if (user) {
+        try {
+          const fetchedPosts = await fetchPostsByAuthor(user._id); // 모든 포스트를 받아옴
+          setPosts(fetchedPosts); // 포스트 목록 상태에 저장
+        } catch (err) {
+          console.error('Failed to load posts:', err);
+          setError('포스트를 불러오는 데 실패했습니다.');
+        }
+      }
+    };
+    
+    loadPosts(); // 포스트 로드 함수 호출
+  }, [user]); // user가 변경될 때마다 실행
+
+  // user가 없을 경우 로딩 메시지 표시
+  if (!user) {
+    return <p>사용자 정보를 불러오는 중입니다...</p>; // 로딩 상태 표시
+  }
+
+  return (
+    <Container>
+      <Header>
+        <ProfileImage src={user?.image || defaultProfileImage} alt="프로필" />
+        <ProfileInfo>
+          <h1>{isMyPage ? '내 프로필' : `${user.fullName.nickName}의 프로필`}</h1>
+          <p>닉네임: {user.fullName.nickName}</p>
+          <p>소개: {user.fullName.bio}</p>
+        </ProfileInfo>
+      </Header>
+      
+      <Content>
+        <PostSection>
+          <h2>추천 포스트</h2>
+          {error && <p>{error}</p>} {/* 에러 메시지 표시 */}
+          <div>
+            {posts.length > 0 ? (
+              posts.map((post) => (
+                <PostCard key={post._id} post={post} />
+              ))
+            ) : (
+              <p>포스트가 없습니다.</p>
+            )}
+          </div>
+        </PostSection>
+
+        <MusicSection>
+          <h2>음원 목록</h2>
+          {/* 음원 목록을 여기에 추가 */}
+        </MusicSection>
+      </Content>
+    </Container>
+  );
+};
+
+export default ProfilePageWrapper; // ProfilePageWrapper를 내보냄
+
+// Styled Components
+
+const Container = styled.div`
+  padding: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const ProfileImage = styled.img`
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-right: 20px;
+`;
+
+const ProfileInfo = styled.div`
+  h1 {
+    font-size: 2rem;
+    margin-bottom: 10px;
+  }
+  
+  p {
+    font-size: 1.2rem;
+    margin: 5px 0;
+  }
+`;
+
+const Content = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const PostSection = styled.div`
+  flex: 1;
+  margin-right: 20px;
+`;
+
+const MusicSection = styled.div`
+  flex: 1;
+`;

--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -39,37 +39,39 @@ const ProfilePage = ({ user, isMyPage }) => {
   }
 
   return (
-    <Container>
-      <Header>
-        <ProfileImage src={user?.image || defaultProfileImage} alt="프로필" />
-        <ProfileInfo>
-          <h1>{isMyPage ? '내 프로필' : `${user.fullName.nickName}의 프로필`}</h1>
-          <p>닉네임: {user.fullName.nickName}</p>
-          <p>소개: {user.fullName.bio}</p>
-        </ProfileInfo>
-      </Header>
-      
-      <Content>
-        <PostSection>
-          <h2>추천 포스트</h2>
-          {error && <p>{error}</p>} {/* 에러 메시지 표시 */}
-          <div>
-            {posts.length > 0 ? (
-              posts.map((post) => (
-                <PostCard key={post._id} post={post} />
-              ))
-            ) : (
-              <p>포스트가 없습니다.</p>
-            )}
-          </div>
-        </PostSection>
+  <Container>
+    <Header>
+      <ProfileImage src={user?.image || defaultProfileImage} alt="프로필" />
+      <ProfileInfo>
+        <h2>{user.fullName.nickName}</h2>
+        <Role><div>{user.role}</div></Role>
+        <Bio>
+          <p>{user.fullName.bio}</p>
+        </Bio>
+      </ProfileInfo>
+    </Header>
 
-        <MusicSection>
-          <h2>음원 목록</h2>
-          {/* 음원 목록을 여기에 추가 */}
-        </MusicSection>
-      </Content>
-    </Container>
+    <Content>
+      <PostSection>
+        <h2>{user.fullName.nickName}의 추천 포스트</h2>
+        {error && <p>{error}</p>} {/* 에러 메시지 표시 */}
+        <div>
+          {posts.length > 0 ? (
+            posts.map((post) => (
+              <PostCard key={post._id} post={post} />
+            ))
+          ) : (
+            <p>포스트가 없습니다.</p>
+          )}
+        </div>
+      </PostSection>
+      <Separator><div></div></Separator>
+      <MusicSection>
+        <h2>{user.fullName.nickName}의 음원</h2>
+        {/* 음원 목록을 여기에 추가 */}
+      </MusicSection>
+    </Content>
+  </Container>
   );
 };
 
@@ -86,39 +88,109 @@ const Container = styled.div`
 const Header = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 30px;
+  margin-bottom: 20px;
+  background: linear-gradient(135deg, #dac8e6, #e2a1f5);
+  color: #000000;
+  border-radius: 10px;
 `;
 
 const ProfileImage = styled.img`
-  width: 150px;
-  height: 150px;
+  width: 160px;
+  height: 160px;
   border-radius: 50%;
   object-fit: cover;
-  margin-right: 20px;
+  margin: 20px;
 `;
 
 const ProfileInfo = styled.div`
-  h1 {
-    font-size: 2rem;
-    margin-bottom: 10px;
+  align-items: center;
+  h2 {
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin: 3px 3px;
   }
-  
+`;
+
+const Role = styled.div`
+  text-align: center;
+  font-weight: 700;
+
+  div {
+    width: 120px;
+    display: flex;
+    background: #DBEDED;
+    border-radius: 35px;
+    font-size: 12px;
+    color: #474150;
+    justify-content: center;
+    margin-top: 5px;
+    padding: 2px;
+    border: 0.7px solid black;
+  }
+`;
+
+const Bio = styled.div`
+  background-color: #ffffff;
+  width: 300px;
+  height: 80px;
+  border-radius: 10px;
+
   p {
-    font-size: 1.2rem;
-    margin: 5px 0;
+    font-size: 0.9rem;
+    padding: 10px;
+    font-weight: 400;
+    margin-top: 10px;
   }
 `;
 
 const Content = styled.div`
   display: flex;
   justify-content: space-between;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
 `;
 
 const PostSection = styled.div`
-  flex: 1;
-  margin-right: 20px;
+  flex: 2;
+  padding-right: 20px; /* 선과 포스트 사이 간격 */
+  position: relative;
+
+  h2 {
+    font-size: 20px;
+    font-weight: 400;
+    border-bottom: 1px solid #000000;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+  }
 `;
 
 const MusicSection = styled.div`
   flex: 1;
+  min-width: 250px;
+  padding-left: 20px; /* 선과 음원 텍스트 사이 간격 추가 */
+
+  h2 {
+    font-size: 20px;
+    font-weight: 400;
+    border-bottom: 1px solid #000000;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+  }
+
+  @media (max-width: 768px) {
+    padding-left: 0; /* 화면이 줄어들 때 간격 제거 */
+    border-left: none; /* 화면이 작아질 때 선 제거 */
+  }
+`;
+
+const Separator = styled.div`
+  width: 1px;
+  background-color: #000000; /* 선 색상 */
+  height: auto; /* 부모 높이에 맞추기 */
+  
+  @media (max-width: 768px) {
+    display: none; /* 작은 화면에서는 선 숨기기 */
+  }
 `;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -27,6 +27,28 @@ export const login = async (email, password) => {
   return response.data;
 };
 
+// 로그아웃 API 호출 함수
+export const logout = async () => {
+  try {
+    // 로그아웃 요청 보내기
+    const response = await fetch('/api/logout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('로그아웃 실패');
+    }
+
+    return response;
+  } catch (error) {
+    console.error('로그아웃 중 오류 발생:', error);
+    throw error;
+  }
+};
+
 // 사용자 정보 가져오기 API 호출
 export const getUserData = async (userId, token) => {
   if (!userId) {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -154,3 +154,19 @@ export const getChannelPosts = async (
     throw error;
   }
 };
+
+// 유저의 포스트 목록을 가져오는 함수
+export const fetchPostsByAuthor = async (authorId, offset = 0, limit = 10) => {
+  try {
+    const response = await axios.get(`/api/posts/author/${authorId}`, {
+      params: {
+        offset, // 페이징을 위한 offset 파라미터
+        limit, // 페이징을 위한 limit 파라미터
+      },
+    });
+    return response.data; // 포스트 목록 리턴
+  } catch (error) {
+    console.error('Error fetching posts by author:', error);
+    throw error; // 에러가 발생하면 throw
+  }
+};


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 마이페이지/ 유저페이지 구현

## 📝 구현한 내용
- 로컬에 저장된 user의 정보와 유저카드/ 네비게이션을 눌렀을 때 이동하는 페이지의 엔드포인트를 비교하여 isMyPage가 true면 마이페이지, false면 유저페이지로 구현
- 유저페이지에서는 로그아웃, 정보수정 버튼이 보이지 않도록 함

<img width="1099" alt="스크린샷 2024-10-03 오후 4 52 32" src="https://github.com/user-attachments/assets/d13ce059-7f8c-42ad-966e-fe82cec8a85e">
<img width="555" alt="스크린샷 2024-10-03 오후 4 53 03" src="https://github.com/user-attachments/assets/e58c7869-a568-4c2b-b125-26bd6b76104a">

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 좋아요한 포스트 목록을 미리 구현할까 생각했는데 관련 api가 없는 것 같습니다... 구현하려면 고민 좀 해봐야할듯?
- 정보수정모달에서 x를 눌러도 닫히지 않는 버그 있음
- 포스트 카드 크기 조정 필요
- user의 role이 비어있는 줄 알았는데 관리자와 일반 사용자를 구분하는 거였네요... 칭호를 한다면 다른 곳에 넣어야할 것 같습니다

## 🔗 연관된 이슈
- close #77
- close #67
