### PR TITLE
[fix]: 정보수정 모달 정상화

### DIFF
--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { fetchPostsByAuthor, logout } from '../utils/api'; 
@@ -9,8 +9,16 @@ import defaultProfileImage from '../assets/images/default-profile.png';
 const ProfilePage = ({ user, isMyPage }) => {
   const [posts, setPosts] = useState([]);
   const [error, setError] = useState(null);
-  const [isEditModalOpen, setEditModalOpen] = useState(false);
   const navigate = useNavigate();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const updateUserDetails = useCallback((updatedUser) => {
+    console.log('Updating user details:', updatedUser);
+    localStorage.setItem('user', JSON.stringify(updatedUser));
+  }, []);
+
+  const openModalHandler = () => setIsModalOpen(true);
+  const closeModalHandler = () => setIsModalOpen(false);
 
   // 유저가 작성한 포스트를 불러옴
   useEffect(() => {
@@ -68,7 +76,7 @@ const ProfilePage = ({ user, isMyPage }) => {
             <h2>{userFullName.nickName || '이름 없음'}</h2>
             {isMyPage && (
               <>
-                <EditButton onClick={() => setEditModalOpen(true)}>✏️ 회원정보 수정</EditButton>
+                <EditButton onClick={openModalHandler}>✏️ 회원정보 수정</EditButton>
                 <LogoutButton onClick={handleLogout} disabled={isLoggingOut}>🚪 로그아웃</LogoutButton>
               </>
             )}
@@ -98,10 +106,12 @@ const ProfilePage = ({ user, isMyPage }) => {
           <h2>{userFullName.nickName || '이름 없음'}의 음원</h2>
         </MusicSection>
       </Content>
-      {isEditModalOpen && (
-        <ProfileEditModal 
-          user={user} 
-          closeModal={() => setEditModalOpen(false)}  
+      {isModalOpen && (
+        <ProfileEditModal
+          user={user}
+          token={localStorage.getItem('token')}
+          onClose={closeModalHandler}
+          setUser={updateUserDetails}
         />
       )}
     </Container>


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 정보수정이 적용되지 않고 모달창이 잘 닫히지 않는 문제 해결

## 📝 구현한 내용
- 업데이트 내용이 잘 반영되고, 모달창이 잘 닫히도록 상태관리를 추가함

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 정보 수정 후에 바로 재렌더링이 되도록 하려고 했지만 유저카드의 user값을 받아와서 프로필페이지를 렌더링하기 때문에 (프로필 페이지 코드 상에서는) 로컬의 유저 상태관리 로직 구현이 어려움

## 🔗 연관된 이슈
- close #81
