### PR TITLE
[Feat]: PostCard 기능 수정

### DIFF
--- a/src/components/CurationCard.jsx
+++ b/src/components/CurationCard.jsx
@@ -18,7 +18,7 @@ const AlbumCurationCard = () => {
         params: { query: '2024 k-pop , j-pop song' },
         headers: {
           'x-rapidapi-key':
-            '053f682234msh54d68575184242bp177e08jsn83138cb78fd6',
+            '44e584cb92msh419c63d530f9731p198f8ejsn087035d40a78',
           'x-rapidapi-host': 'youtube-music6.p.rapidapi.com',
         },
       };

--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -7,6 +7,7 @@ import playButtonIcon from '../assets/icons/play-button.png';
 import pauseButtonIcon from '../assets/icons/stop-button.png';
 import PostDetailModal from '../components/modals/PostDetailModal';
 import { getPostDetails } from '../utils/api';
+import ReactionCount from '../components/ReactionCount'; // ReactionCount 컴포넌트 import
 
 // 정적 변수로 현재 재생 중인 플레이어 관리
 let currentPlayingPlayer = null;
@@ -18,6 +19,8 @@ const PostCard = ({ post, onLikeUpdate, onPostDelete }) => {
   const [isPlayerReady, setIsPlayerReady] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedPost, setSelectedPost] = useState(null);
+  const [likes, setLikes] = useState(post.likes.length);
+  const [comments, setComments] = useState(post.comments.length);
   const playerRef = useRef(null);
   const navigate = useNavigate();
 
@@ -136,9 +139,14 @@ const PostCard = ({ post, onLikeUpdate, onPostDelete }) => {
   };
 
   const handleLikeUpdate = (postId, isLiked, newLikeCount) => {
+    setLikes(newLikeCount);
     if (onLikeUpdate) {
       onLikeUpdate(postId, isLiked, newLikeCount);
     }
+  };
+
+  const handleCommentUpdate = (newCommentCount) => {
+    setComments(newCommentCount);
   };
 
   const handlePostDelete = async (postId) => {
@@ -181,6 +189,9 @@ const PostCard = ({ post, onLikeUpdate, onPostDelete }) => {
         <CardContent>
           <PostTitle>{parsedTitle}</PostTitle>
           <PostDescription>{description}</PostDescription>
+          <ReactionCountWrapper>
+            <ReactionCount likes={likes} comments={comments} />
+          </ReactionCountWrapper>
         </CardContent>
         {firstAlbum && firstAlbum.videoId && (
           <YouTubePlayerContainer>
@@ -205,6 +216,7 @@ const PostCard = ({ post, onLikeUpdate, onPostDelete }) => {
           onClose={handleCloseModal}
           onLikeUpdate={handleLikeUpdate}
           onPostDelete={handlePostDelete}
+          onCommentUpdate={handleCommentUpdate}
         />
       )}
     </>
@@ -329,4 +341,8 @@ const PlayButtonImage = styled.img`
 
 const YouTubePlayerContainer = styled.div`
   display: none;
+`;
+
+const ReactionCountWrapper = styled.div`
+  margin-top: 10px;
 `;

--- a/src/components/ReactionCount.jsx
+++ b/src/components/ReactionCount.jsx
@@ -1,75 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import likeIcon from '../assets/icons/Like.png';
 import commentIcon from '../assets/icons/Comment.png';
 
-// 더미 포스트 데이터
-const dummyPosts = [
-  {
-    _id: 'post-1',
-    likes: Array.from({ length: 10 }), // 10명의 사용자가 좋아요를 누른 것으로 가정
-    comments: Array.from({ length: 5 }, (_, i) => `Comment ${i + 1}`), // 5개의 댓글
-    title: '첫 번째 게시물',
-    author: { fullName: '사용자 1' },
-  },
-  {
-    _id: 'post-2',
-    likes: Array.from({ length: 23 }), // 23개의 좋아요
-    comments: Array.from({ length: 8 }, (_, i) => `Comment ${i + 1}`), // 8개의 댓글
-    title: '두 번째 게시물',
-    author: { fullName: '사용자 2' },
-  },
-  {
-    _id: 'post-3',
-    likes: Array.from({ length: 15 }), // 15개의 좋아요
-    comments: Array.from({ length: 3 }, (_, i) => `Comment ${i + 1}`), // 3개의 댓글
-    title: '세 번째 게시물',
-    author: { fullName: '사용자 3' },
-  },
-  {
-    _id: 'post-4',
-    likes: Array.from({ length: 50 }), // 50개의 좋아요
-    comments: Array.from({ length: 12 }, (_, i) => `Comment ${i + 1}`), // 12개의 댓글
-    title: '네 번째 게시물',
-    author: { fullName: '사용자 4' },
-  },
-  {
-    _id: 'post-5',
-    likes: Array.from({ length: 30 }), // 30개의 좋아요
-    comments: Array.from({ length: 9 }, (_, i) => `Comment ${i + 1}`), // 9개의 댓글
-    title: '다섯 번째 게시물',
-    author: { fullName: '사용자 5' },
-  },
-];
-
-// ReactionCount 컴포넌트: 게시물의 좋아요 수와 댓글 수를 표시합니다.
-const ReactionCount = ({ postId }) => {
-  const [likes, setLikes] = useState(0);
-  const [comments, setComments] = useState(0);
-
-  useEffect(() => {
-    const post = dummyPosts.find((p) => p._id === postId);
-    if (post) {
-      setLikes(post.likes.length); // 더미 데이터의 좋아요 수 사용
-      setComments(post.comments.length); // 더미 데이터의 댓글 수 사용
-    }
-  }, [postId]);
-
-  /* 추후 API 데이터 생성 후 테스트
-  useEffect(() => {
-    /* const loadReactions = async () => {
-      try {
-        const data = await fetchPostReactions(postId); // API 함수 호출
-        setLikes(data.likes.length);
-        setComments(data.comments.length);
-      } catch (error) {
-        console.error("Error loading reactions:", error);
-      }
-    };
-
-    loadReactions(); 
-  }, [postId]);*/
-
+const ReactionCount = ({ likes, comments }) => {
   return (
     <MetricsContainer>
       <MetricItem>
@@ -88,33 +22,8 @@ const ReactionCount = ({ postId }) => {
   );
 };
 
-// 테스트를 위한 App 컴포넌트
-const App = () => {
-  const [postIds, setPostIds] = useState([]);
+export default ReactionCount;
 
-  useEffect(() => {
-    const ids = ['post-1', 'post-2', 'post-3', 'post-4', 'post-5'];
-    setPostIds(ids); // 더미 데이터에 해당하는 ID로 설정
-  }, []);
-
-  return (
-    <AppContainer>
-      <h1>게시물 반응 카운트 테스트</h1>
-      <UserList>
-        {postIds.map((id) => (
-          <PostContainer key={id}>
-            <h2>게시물 ID: {id}</h2>
-            <ReactionCount postId={id} />
-          </PostContainer>
-        ))}
-      </UserList>
-    </AppContainer>
-  );
-};
-
-export default App;
-
-// 스타일 정의
 const MetricsContainer = styled.div`
   display: flex;
   align-items: center;
@@ -127,6 +36,8 @@ const MetricItem = styled.div`
 `;
 
 const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
   margin-right: 4px;
 `;
 
@@ -138,24 +49,7 @@ const Icon = styled.img`
 const Count = styled.span`
   font-size: 14px;
   color: #333;
-`;
-
-const AppContainer = styled.div`
-  max-width: 600px;
-  margin: 0 auto;
-  padding: 20px;
-  font-family: Arial, sans-serif;
-`;
-
-const PostContainer = styled.div`
-  background-color: #f0f0f0;
-  border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 16px;
-`;
-
-const UserList = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  font-weight: bold;
+  position: relative;
+  top: -1px; // 숫자를 약간 위로 올립니다
 `;

--- a/src/components/modals/PostDetailModal.jsx
+++ b/src/components/modals/PostDetailModal.jsx
@@ -23,6 +23,7 @@ const PostDetailModal = ({
   onClose,
   onLikeUpdate,
   onPostDelete,
+  onCommentUpdate,
 }) => {
   const [currentAlbumIndex, setCurrentAlbumIndex] = useState(0);
   const [comment, setComment] = useState('');
@@ -162,15 +163,25 @@ const PostDetailModal = ({
     setIsPlaying(false);
   };
 
+  useEffect(() => {
+    setComments(initialPost.comments);
+    setCommentCount(initialPost.comments.length);
+  }, [initialPost]);
+
   const handleCommentSubmit = async (e) => {
     e.preventDefault();
     try {
       if (!comment.trim() || !currentUser) return;
       const newComment = await addComment(post._id, comment, token);
-      console.log('New comment:', newComment);
       setComments((prevComments) => [newComment, ...prevComments]);
       setComment('');
-      setCommentCount((prevCount) => prevCount + 1); // 댓글 수 증가
+      setCommentCount((prevCount) => {
+        const newCount = prevCount + 1;
+        if (onCommentUpdate) {
+          onCommentUpdate(newCount); // postId 제거, 댓글 수만 전달
+        }
+        return newCount;
+      });
     } catch (error) {
       console.error('댓글 작성 중 오류 발생:', error);
       alert('댓글 작성 중 오류가 발생했습니다.');
@@ -183,7 +194,13 @@ const PostDetailModal = ({
       setComments((prevComments) =>
         prevComments.filter((comment) => comment._id !== commentId),
       );
-      setCommentCount((prevCount) => prevCount - 1); // 댓글 수 감소
+      setCommentCount((prevCount) => {
+        const newCount = prevCount - 1;
+        if (onCommentUpdate) {
+          onCommentUpdate(newCount); // postId 제거, 댓글 수만 전달
+        }
+        return newCount;
+      });
     } catch (error) {
       console.error('댓글 삭제 중 오류 발생:', error);
       alert('댓글을 삭제할 수 없습니다. 다시 시도해 주세요.');

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -115,11 +115,15 @@ export const updateUser = async (userId, token, updatedData) => {
 // 포스트의 좋아요 및 댓글 수를 가져오는 API
 export const fetchPostReactions = async (postId) => {
   try {
-    const response = await axios.get(`${API_HOST}/posts/${postId}`);
-    return response.data; // 실제로 필요한 데이터 반환
+    const response = await axios.get(`/posts/${postId}`);
+    const post = response.data;
+    return {
+      likes: post.likes.length,
+      comments: post.comments.length,
+    };
   } catch (error) {
     console.error('Error fetching post reactions:', error);
-    throw error; // 에러를 호출한 곳에서 처리할 수 있도록 throw
+    throw error;
   }
 };
 


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 포스트 카드에서 프로필 누르면 해당 작성자의 프로필 페이지로 이동하도록 구현
- 포스트 카드에 모달에서 적용된 좋아요 수와 댓글 수 실시간으로 받아와 표시하게 되는 기능 구현

## 📝 구현한 내용
- 포스트카드에서 헤더 프로필 부분에 마우스 갖다 대면 밑줄이 생기며, 영역을 구분할 수 있게 구현
- 포스트 카드에서 프로필 부분 누르면 해당 작성자의 프로필 페이지로 넘어가도록 구현
- 포스트 카드에서 카운트 리액션 컴포넌트 넣고 실시간으로 갯수 가져올 수 있도록 구현
![화면 캡처 2024-10-05 035459](https://github.com/user-attachments/assets/fb66b975-2b61-478c-ac96-da7a94171132)

## ✅ 체크리스트
- [ ] 이슈 내용 모두 적용
- [ ] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 상세 모달에서도 프로필로 이동할 수 있도록 구현하겠습니다!
- 반응형도 추가적으로 진행하겠습니다!

## 🔗 연관된 이슈
- close #94 
