### PR TITLE
[Feat] 아티스트 음원 상세 모달 구현

### DIFF
--- a/src/components/ArtistCard.jsx
+++ b/src/components/ArtistCard.jsx
@@ -334,7 +334,7 @@ const CardContainer = styled.div`
 const PostWrapper = styled.div`
   flex: none;
   width: 300px;
-  height: 480px;
+  height: 490px;
   margin: 10px;
   border-radius: 10px;
   overflow: hidden;
@@ -495,8 +495,17 @@ const SongInformation = styled.p`
   color: #666666;
   font-size: 12px;
   margin-bottom: 10px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  line-height: 1.2em;
+  height: 2.4em; // line-height * 2줄
 `;
 
 const ReactionCountWrapper = styled.div`
   margin-top: 20px; // 소개글과의 간격 조정
+  margin-bottom: 20px;
 `;

--- a/src/components/ArtistCard.jsx
+++ b/src/components/ArtistCard.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import { getChannelPosts, getPostDetails } from '../utils/api';
 import playButtonIcon from '../assets/icons/play-button.png';
 import stopButtonIcon from '../assets/icons/stop-button.png';
@@ -14,6 +15,7 @@ const ArtistCard = ({ onLikeUpdate, onPostDelete }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedPost, setSelectedPost] = useState(null);
   const audioRefs = useRef([]);
+  const navigate = useNavigate();
 
   const channelId = '66fb53f9ed2d3c14a64eb9ea';
 
@@ -121,6 +123,11 @@ const ArtistCard = ({ onLikeUpdate, onPostDelete }) => {
     );
   };
 
+  const handleProfileClick = (e, authorId) => {
+    e.stopPropagation();
+    navigate(`/user/${authorId}`);
+  };
+
   const parseAuthorNickName = (author) => {
     let nickName = '익명';
 
@@ -152,7 +159,9 @@ const ArtistCard = ({ onLikeUpdate, onPostDelete }) => {
 
         return (
           <PostWrapper key={post._id} onClick={(e) => handleCardClick(e, post)}>
-            <ArtistInfo className="profile-area">
+            <ArtistInfo
+              className="profile-area"
+              onClick={(e) => handleProfileClick(e, post.author._id)}>
               <ArtistAvatar
                 src={post.author.image || defaultProfileImage}
                 alt={nickName}

--- a/src/components/modals/ArtistTrackDetailModal.jsx
+++ b/src/components/modals/ArtistTrackDetailModal.jsx
@@ -1,7 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
-import PreviousBtn from '../../assets/icons/Previous-Btn.png';
-import NextBtn from '../../assets/icons/Next-Btn.png';
 import PlayBtn from '../../assets/icons/play-button-2.png';
 import StopBtn from '../../assets/icons/stop-button-2.png';
 import LikeIcon from '../../assets/icons/Like.png';
@@ -24,7 +22,6 @@ const ArtistTrackDetailModal = ({
   onTrackDelete,
   onCommentUpdate,
 }) => {
-  const [currentAlbumIndex, setCurrentAlbumIndex] = useState(0);
   const [comment, setComment] = useState('');
   const [isPlaying, setIsPlaying] = useState(false);
   const [isLiked, setIsLiked] = useState(false);
@@ -121,6 +118,7 @@ const ArtistTrackDetailModal = ({
 
   const { title, albums, description, authorNickname, authorImage } =
     parseTrackData(track);
+  const album = albums[0]; // 단일 앨범 사용
 
   useEffect(() => {
     fetchTrackDetails();
@@ -257,30 +255,19 @@ const ArtistTrackDetailModal = ({
         </Header>
         <Divider />
 
-        <AlbumSection>
-          <AlbumNavButton onClick={handlePrevAlbum}>
-            <img src={PreviousBtn} alt="Previous" />
-          </AlbumNavButton>
-          <AlbumImageContainer onClick={handlePlayPause}>
-            <AlbumImage
-              src={albums[currentAlbumIndex]?.coverUrl}
-              alt={albums[currentAlbumIndex]?.title}
+        <AlbumImageContainer onClick={handlePlayPause}>
+          <AlbumImage src={album?.coverUrl} alt={album?.title} />
+          <PlayOverlay $isPlaying={isPlaying}>
+            <PlayPauseIcon
+              src={isPlaying ? StopBtn : PlayBtn}
+              alt={isPlaying ? 'Pause' : 'Play'}
             />
-            <PlayOverlay $isPlaying={isPlaying}>
-              <PlayPauseIcon
-                src={isPlaying ? StopBtn : PlayBtn}
-                alt={isPlaying ? 'Pause' : 'Play'}
-              />
-            </PlayOverlay>
-          </AlbumImageContainer>
-          <AlbumNavButton onClick={handleNextAlbum}>
-            <img src={NextBtn} alt="Next" />
-          </AlbumNavButton>
-        </AlbumSection>
+          </PlayOverlay>
+        </AlbumImageContainer>
 
         <AlbumInfo>
-          <AlbumTitle>{albums[currentAlbumIndex]?.title}</AlbumTitle>
-          <AlbumArtist>{albums[currentAlbumIndex]?.artist}</AlbumArtist>
+          <AlbumTitle>{album?.title}</AlbumTitle>
+          <AlbumArtist>{album?.artist}</AlbumArtist>
         </AlbumInfo>
 
         <DescriptionBox>
@@ -343,7 +330,7 @@ const ArtistTrackDetailModal = ({
 
         <audio
           ref={audioRef}
-          src={albums[currentAlbumIndex]?.videoUrl}
+          src={album?.videoUrl}
           onEnded={() => setIsPlaying(false)}
         />
       </ModalContainer>
@@ -441,40 +428,12 @@ const Divider = styled.hr`
   margin-bottom: 20px;
 `;
 
-const AlbumSection = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 20px;
-`;
-
-const AlbumNavButton = styled.button`
-  background: none;
-  border: none;
-  cursor: pointer;
-  width: 24px;
-  height: 24px;
-  margin: 0 20px;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  img {
-    max-width: 80%;
-    max-height: 80%;
-    object-fit: contain;
-  }
-
-  &:hover {
-    opacity: 0.7;
-  }
-`;
-
 const AlbumImageContainer = styled.div`
   width: 250px;
   height: 250px;
   position: relative;
+  cursor: pointer;
+  margin: 0 auto;
 `;
 
 const AlbumImage = styled.img`
@@ -505,31 +464,6 @@ const AudioControls = styled.div`
   align-items: center;
   width: 80%;
   margin: 0 auto 20px;
-`;
-
-const ProgressBarContainer = styled.div`
-  width: 100%;
-  height: 8px;
-  background-color: #c0bfc3;
-  border-radius: 4px;
-  margin-bottom: 10px;
-  cursor: pointer;
-  position: relative;
-`;
-
-const ProgressBarFill = styled.div`
-  height: 100%;
-  background-color: #3f3f44;
-  border-radius: 4px;
-`;
-
-const TimeDisplay = styled.div`
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
-  font-size: 12px;
-  margin-bottom: 10px;
-  color: #666;
 `;
 
 const DescriptionBox = styled.div`
@@ -687,16 +621,16 @@ const PlayOverlay = styled.div`
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  right: 0;
+  bottom: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: rgba(0, 0, 0, 0.5);
-  opacity: ${(props) => (props.$isPlaying ? 1 : 0)};
+  background-color: rgba(0, 0, 0, 0.3);
+  opacity: 0;
   transition: opacity 0.3s ease;
 
-  &:hover {
+  ${AlbumImageContainer}:hover & {
     opacity: 1;
   }
 `;
@@ -704,4 +638,9 @@ const PlayOverlay = styled.div`
 const PlayPauseIcon = styled.img`
   width: 50px;
   height: 50px;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.1);
+  }
 `;

--- a/src/components/modals/ArtistTrackDetailModal.jsx
+++ b/src/components/modals/ArtistTrackDetailModal.jsx
@@ -460,7 +460,7 @@ const AlbumImageContainer = styled.div`
   height: 250px;
   position: relative;
   cursor: pointer;
-  margin: 0 auto;
+  margin: 30px auto; // 상하 마진을 30px로 설정
 `;
 
 const AlbumImage = styled.img`
@@ -471,7 +471,8 @@ const AlbumImage = styled.img`
 
 const AlbumInfo = styled.div`
   text-align: center;
-  margin-bottom: 20px;
+  margin-top: 30px; // 상단 마진 추가
+  margin-bottom: 30px; // 20px에서 30px로 증가
 `;
 
 const AlbumTitle = styled.h3`
@@ -485,21 +486,15 @@ const AlbumArtist = styled.p`
   color: #666;
 `;
 
-const AudioControls = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 80%;
-  margin: 0 auto 20px;
-`;
-
 const DescriptionBox = styled.div`
   background-color: #c0afe2;
   border-radius: 10px;
   padding: 15px;
-  margin-bottom: 20px;
-  width: 280px;
-  max-height: 150px;
+  margin-top: 30px;
+  margin-bottom: 30px;
+  width: 90%;
+  max-width: 400px;
+  max-height: 200px;
   overflow-y: auto;
   margin-left: auto;
   margin-right: auto;
@@ -509,9 +504,12 @@ const Description = styled.p`
   font-size: 14px;
   line-height: 1.5;
   margin: 0;
-  text-align: center;
+  text-align: left;
   color: #fff;
   font-weight: bold;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: break-word;
 `;
 
 const LikeSection = styled.div`


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 아티스트 음원 상세 모달 구현 완료

## 📝 구현한 내용
- 아티스트 카드 본문 부분을 누를 경우, 상세 모달이 띄워지도록 구현하였습니다.
- 카드의 헤더 부분을 클릭하면 작성자 프로필 페이지로 이동하도록 구현하였습니다.

## ✅ 체크리스트
- [ ] 이슈 내용 모두 적용
- [ ] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 기능 관련 나누고 싶은 내용 or 리뷰 요구사항 작성

## 🔗 연관된 이슈
- close #20 
