### PR TITLE
[fix] 알림 모달창을 닫고나서도 도트가 사라지지 않는 버그 수정

### DIFF
--- a/src/components/main/Navigation.jsx
+++ b/src/components/main/Navigation.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Link } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import styled from 'styled-components';
-// 버튼 이미지 파일
 import HomeIcon from '../../assets/icons/Home.png';
 import CurationArtistIcon from '../../assets/icons/CurationArtist.png';
 import PostFeedIcon from '../../assets/icons/PostFeed.png';
@@ -10,71 +8,84 @@ import BellIcon from '../../assets/icons/Bell.png';
 import DefaultProfileImage from '../../assets/images/default-profile.png';
 import SearchIcon from '../../assets/icons/Search.png';
 import LogoImage from '../../assets/images/Logo.png';
-// 모달 파일
 import UploadModal from '../modals/UploadModal';
 import NotificationModal from '../modals/NotificationModal';
+import { getNotifications } from '../../utils/api.js'; // API 호출을 위한 함수 가져오기
 
 const Navigation = () => {
-  const [searchTerm, setSearchTerm] = useState(''); // 검색어 상태
-  const [isModalOpen, setIsModalOpen] = useState(false); // 모달 상태
-  const [user, setUser] = useState(null); // 유저 상태
-  const navigate = useNavigate(); // useNavigate 훅 사용
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [user, setUser] = useState(null);
   const [showModal, setShowModal] = useState(false);
-  const [unseenNotifications, setUnseenNotifications] = useState(true); // 확인하지 않은 알림 상태
+  const [unseenNotifications, setUnseenNotifications] = useState(false); // 초기값을 false로 설정
+  const navigate = useNavigate();
 
-  const handleNotificationClick = () => { 
-    setShowModal(true); 
-    setUnseenNotifications(false); // 모달 열 때 주홍색 점 숨김
+// 알림을 가져오는 함수
+const fetchNotifications = async () => {
+  const token = localStorage.getItem('token');
+  if (!token) return; // 토큰이 없으면 종료
+
+  try {
+    const fetchedNotifications = await getNotifications(token); // API를 통해 알림 데이터를 가져옴
+
+    // 확인되지 않은 알림의 수를 계산합니다.
+    const unseenNotifications = fetchedNotifications.filter(notification => !notification.seen);
+    const unseenCount = unseenNotifications.length; // 확인되지 않은 알림의 수
+
+    setUnseenNotifications(unseenCount); // 상태 업데이트: 확인되지 않은 알림의 수
+  } catch (error) {
+    console.error('Error fetching notifications:', error);
+    // 여기서 사용자에게 알림 오류를 알려줄 수 있는 로직을 추가할 수 있습니다.
+    setError('알림을 불러오는 데 실패했습니다.'); // 오류 메시지 상태 업데이트
+  }
+};
+
+  // 컴포넌트가 마운트될 때 알림을 가져옴
+  useEffect(() => {
+    fetchNotifications(); // 알림을 가져옴
+  }, []); // 빈 배열을 넣어 컴포넌트가 처음 렌더링될 때 한 번만 실행
+
+  const handleNotificationClick = () => {
+    setShowModal(true);
+    setUnseenNotifications(false); // 모달 열 때 도트 숨김
   };
-  
-  const handleCloseModal = () => { 
-    setShowModal(false); 
+
+  const handleCloseModal = () => {
+    setShowModal(false);
   };
 
-  // 모달 열기/닫기 함수
-  const openModal = () => setIsModalOpen(true);
-  const closeModal = () => setIsModalOpen(false);
-
-  // 로컬 스토리지에서 유저 정보 가져오기
   useEffect(() => {
     const storedUser = localStorage.getItem('user');
     if (storedUser) {
-      setUser(JSON.parse(storedUser)); // 로컬 스토리지에서 가져온 유저 정보 파싱
+      setUser(JSON.parse(storedUser));
     }
   }, []);
 
-  // 프로필 클릭 시 해당 유저 페이지로 이동
   const handleProfileClick = () => {
     if (user && user._id) {
-      navigate(`/user/${user._id}`); // 유저의 _id를 기반으로 이동
+      navigate(`/user/${user._id}`);
     }
   };
 
   return (
     <>
       <HeaderContainer>
-        {/* 로고 섹션 */}
         <Logo>
           <img src={LogoImage} alt="로고" />
         </Logo>
 
-        {/* 네비게이션 바 섹션 */}
         <Navbar>
-          {/* 홈 아이콘 */}
           <NavItem href="/main">
             <img src={HomeIcon} alt="Home" />
           </NavItem>
-          {/* 큐레이션 및 아티스트 트랙 아이콘 */}
           <NavItem href="/curationart">
             <img src={CurationArtistIcon} alt="큐레이션 & 아티스트 트랙" />
           </NavItem>
-          {/* 포스트 피드 아이콘 */}
           <NavItem as={Link} to="/postfeed">
             <img src={PostFeedIcon} alt="포스트" />
           </NavItem>
         </Navbar>
 
-        {/* 검색창 및 업로드 버튼 섹션 */}
         <SearchUploadContainer>
           <SearchBar>
             <input
@@ -88,19 +99,16 @@ const Navigation = () => {
             </a>
           </SearchBar>
 
-          {/* 업로드 버튼 */}
           <Upload>
-            <RoundButton onClick={openModal}>
+            <RoundButton onClick={() => setIsModalOpen(true)}>
               <a>Upload</a>
             </RoundButton>
           </Upload>
         </SearchUploadContainer>
 
-        {/* 프로필 및 알림 섹션 */}
         <ProfileSection>
           <div className="title">칭호 없음</div>
 
-          {/* 프로필 클릭 시 유저 페이지로 이동 */}
           <a onClick={handleProfileClick}>
             <img
               className="profile"
@@ -109,7 +117,6 @@ const Navigation = () => {
             />
           </a>
 
-          {/* 알림 아이콘 */}
           <NotificationButton onClick={handleNotificationClick} unseen={unseenNotifications}>
             <img src={BellIcon} alt="알림" />
           </NotificationButton>
@@ -117,12 +124,11 @@ const Navigation = () => {
         </ProfileSection>
       </HeaderContainer>
 
-      {/* 업로드 모달 */}
       {isModalOpen && (
         <>
           <ModalBackground />
           <ModalContainer>
-            <UploadModal onClose={closeModal} />
+            <UploadModal onClose={() => setIsModalOpen(false)} />
           </ModalContainer>
         </>
       )}

--- a/src/components/modals/NotificationModal.jsx
+++ b/src/components/modals/NotificationModal.jsx
@@ -7,7 +7,6 @@ const NotificationModal = ({ show, onClose }) => {
   const [notifications, setNotifications] = useState([]); // 알림 데이터를 저장하는 상태
   const [loading, setLoading] = useState(true); // 로딩 상태를 관리하는 상태
   const [error, setError] = useState(''); // 오류 메시지를 저장하는 상태
-  const [unseenNotifications, setUnseenNotifications] = useState(false); // 확인하지 않은 알림 상태 추가
 
   // 알림 데이터를 서버에서 불러오는 함수
   const fetchNotifications = async () => {
@@ -17,10 +16,6 @@ const NotificationModal = ({ show, onClose }) => {
       const fetchedNotifications = await getNotifications(token); // API를 통해 알림 데이터를 가져옴
       console.log('Fetched Notifications:', fetchedNotifications);
       setNotifications(fetchedNotifications); // 알림 데이터를 상태에 저장
-
-      // 확인하지 않은 알림이 있는지 체크
-      const hasUnseen = fetchedNotifications.some(notification => !notification.seen);
-      setUnseenNotifications(hasUnseen); // 주홍색 점 표시 여부 업데이트
     } catch (error) {
       console.error('Error fetching notifications:', error); // 에러 발생 시 콘솔에 에러를 출력
       setError('알림을 불러오는 데 실패했습니다.'); // 사용자에게 표시할 오류 메시지 설정
@@ -52,15 +47,10 @@ const NotificationModal = ({ show, onClose }) => {
           notification._id === notificationId ? { ...notification, seen: true } : notification
         )
       ); // 클릭한 알림을 '본 것으로' 처리하여 UI 업데이트
-
-      // 확인하지 않은 알림 상태 업데이트
-      const updatedUnseen = prevNotifications.some(notification => !notification.seen);
-      setUnseenNotifications(updatedUnseen);
     } catch (error) {
       console.error('Error marking notification as seen:', error);
     }
   };
-  
 
   // 알림 작성자의 이름을 가져오는 함수 (닉네임이 없을 경우 전체 이름 또는 'Unknown'을 반환)
   const getAuthorName = (author) => {


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 알림 모달창을 닫고나서도 도트가 사라지지 않는 버그 수정

## 📝 구현한 내용
- 알림 모달창을 닫고나서도 도트가 사라지지 않는 버그 수정
- 모달창 스크롤 수정

## ✅ 체크리스트
- [ ] 이슈 내용 모두 적용
- [ ] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 이것저것 다해봤는데 모달 열고 알림 여러개 중에 하나 누르고, 다시 닫고 새로고침하면 알림을 전부 확인한 게 되어 버립니다 ㅎ... 이건 그냥 감안해야할듯? ㅜㅜ 그래도 이제 모달창 닫고 새로고침하면 새로운 알림이 올 때까지 도트가 뜨지 않습니다.!

## 🔗 연관된 이슈
- close #108
