### PR TITLE
[Feat] 메인 페이지(컨텐츠 허브) 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import Navigation from './components/main/Navigation';
 import PostFeed from './pages/PostFeed/PostFeed';
 import ProfilePage from '../src/profile/ProfilePage.jsx';
+import MainPage from './pages/Main/MainPage';
 
 const App = () => {
   const [user, setUser] = useState(null);
@@ -25,13 +26,14 @@ const App = () => {
       </div>
       <Container>
         <Nav>
+          <NavLink to="/">홈</NavLink>  {/* 메인 페이지로 가는 링크 추가 */}
           <NavLink to="/login">로그인</NavLink>
           <NavLink to="/signup">회원가입</NavLink>
           <NavLink to="/dashboard">대시보드</NavLink>
           <NavLink to="/postfeed">포스트 피드</NavLink>
         </Nav>
         <Routes>
-          <Route path="/" element={<Login />} />
+          <Route path="/" element={<MainPage />} />  {/* 메인 페이지 라우트 추가 */}
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/dashboard" element={<Dashboard />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,14 +28,14 @@ const App = () => {
       </div>
       <Container>
         <Nav>
-          <NavLink to="/">홈</NavLink>  {/* 메인 페이지로 가는 링크 추가 */}
+          <NavLink to="/mainpage">홈</NavLink>  {/* 메인 페이지로 가는 링크 추가 */}
           <NavLink to="/login">로그인</NavLink>
           <NavLink to="/signup">회원가입</NavLink>
           <NavLink to="/dashboard">대시보드</NavLink>
           <NavLink to="/postfeed">포스트 피드</NavLink>
         </Nav>
         <Routes>
-          <Route path="/" element={<MainPage />} />  {/* 메인 페이지 라우트 추가 */}
+          <Route path="mainpage/" element={<MainPage />} />  {/* 메인 페이지 라우트 추가 */}
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/dashboard" element={<Dashboard />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,13 +33,16 @@ const App = () => {
           <NavLink to="/signup">회원가입</NavLink>
           <NavLink to="/dashboard">대시보드</NavLink>
           <NavLink to="/postfeed">포스트 피드</NavLink>
+          <NavLink to="/curationart">큐레이션-아티스트</NavLink>
         </Nav>
         <Routes>
+          <Route path="/" element={<Login />} />
           <Route path="mainpage/" element={<MainPage />} />  {/* 메인 페이지 라우트 추가 */}
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/postfeed" element={<PostFeed />} />
+          <Route path="/curationart" element={<CurationArt />} />
           {/* 유저 페이지/마이페이지 */}
           <Route path="/user/:userId" element={<ProfilePageWrapper user={user} />} />
         </Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,11 +7,8 @@ import styled from 'styled-components';
 import Navigation from './components/main/Navigation';
 import PostFeed from './pages/PostFeed/PostFeed';
 import ProfilePage from '../src/profile/ProfilePage.jsx';
-<<<<<<< HEAD
 import MainPage from './pages/Main/MainPage';
-=======
 import CurationArt from './pages/Curation-Artist/CurationArt.jsx';
->>>>>>> 9f28fcc308126ee0237dbdbd29bf44519de44258
 
 const App = () => {
   const [user, setUser] = useState(null);

--- a/src/auth/Dashboard.jsx
+++ b/src/auth/Dashboard.jsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import ProfileEditModal from '../components/modals/ProfileEditModal';
 import { getUserData } from '../utils/api';
 import UserCard from '../components/UserCard';
-import UserProfile from '../components/UserProfile';
 import CurationCard from '../components/CurationCard';
 import ReactionCount from '../components/ReactionCount'; // 리액션 카운트 컴포넌트
 import ArtistCard from '../components/ArtistCard';
@@ -111,7 +110,6 @@ const Dashboard = () => {
         회원 정보 수정
       </EditProfileButton>
       <UserCard user={user} />
-      <UserProfile user={user} />
       <ReactionCount />
       {isModalOpen && (
         <ProfileEditModal

--- a/src/components/CurationCard.jsx
+++ b/src/components/CurationCard.jsx
@@ -17,7 +17,8 @@ const AlbumCurationCard = () => {
         url: 'https://youtube-music6.p.rapidapi.com/ytmusic/',
         params: { query: '2024 k-pop , j-pop song' },
         headers: {
-          'x-rapidapi-key': '',
+          'x-rapidapi-key':
+          '44e584cb92msh419c63d530f9731p198f8ejsn087035d40a78',
           'x-rapidapi-host': 'youtube-music6.p.rapidapi.com',
         },
       };

--- a/src/components/CurationCard.jsx
+++ b/src/components/CurationCard.jsx
@@ -18,7 +18,7 @@ const AlbumCurationCard = () => {
         params: { query: '2024 k-pop , j-pop song' },
         headers: {
           'x-rapidapi-key':
-            '053f682234msh54d68575184242bp177e08jsn83138cb78fd6',
+            '44e584cb92msh419c63d530f9731p198f8ejsn087035d40a78',
           'x-rapidapi-host': 'youtube-music6.p.rapidapi.com',
         },
       };

--- a/src/components/CurationCard.jsx
+++ b/src/components/CurationCard.jsx
@@ -18,7 +18,7 @@ const AlbumCurationCard = () => {
         params: { query: '2024 k-pop , j-pop song' },
         headers: {
           'x-rapidapi-key':
-            '44e584cb92msh419c63d530f9731p198f8ejsn087035d40a78',
+            '474a94c639ec3a9ee5cc079e1d96ffa5687f2765',
           'x-rapidapi-host': 'youtube-music6.p.rapidapi.com',
         },
       };

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -1,13 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import ExampleImage from '../assets/images/default-profile.png';
 import { useNavigate } from 'react-router-dom';
-import { getUsers } from '../utils/api'; 
 
-// 유저 프로필 카드 컴포넌트
-const UserProfileCard = ({ user, onNavigate }) => {
+const UserProfileCard = ({ user }) => {
   const { image, fullName, _id } = user;
   let nickName = '닉네임이 없습니다.';
+  const navigate = useNavigate();
 
   // fullName이 JSON 형식인지 체크한 후 파싱 시도
   if (fullName) {
@@ -25,12 +24,12 @@ const UserProfileCard = ({ user, onNavigate }) => {
   }
 
   const handleCardClick = () => {
-    onNavigate(`/user/${_id}`);
+    navigate(`/user/${_id}`);
   };
 
   return (
-    <Card>
-      <ClickableContent onClick={handleCardClick}>
+    <Card onClick={handleCardClick}>
+      <ClickableContent>
         <ProfileImage src={image || ExampleImage} alt={nickName} />
         <UserInfo>
           <UserName>{nickName}</UserName>
@@ -40,50 +39,16 @@ const UserProfileCard = ({ user, onNavigate }) => {
   );
 };
 
-// 유저 리스트 컴포넌트
-const App = () => {
-  const [users, setUsers] = useState([]);
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    const fetchUsers = async () => {
-      try {
-        const usersData = await getUsers();
-        setUsers(usersData);
-      } catch (error) {
-        console.error('Error fetching users:', error);
-      }
-    };
-
-    fetchUsers();
-  }, []);
-
-  return (
-    <UserList>
-      {users.map((user) => (
-        <UserProfileCard key={user._id} user={user} onNavigate={navigate} />
-      ))}
-    </UserList>
-  );
-};
-
-export default App;
+export default UserProfileCard;
 
 // Styled Components
-const UserList = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
-`;
-
 const Card = styled.div`
   display: flex;
   align-items: center;
-  padding: 15px;
-  border-radius: 15px;
-  width: 180px;
-  height: 230px;
-  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;  // 추가: 카드 내부의 오버플로우를 숨김
 `;
 
 const ClickableContent = styled.div`
@@ -92,6 +57,8 @@ const ClickableContent = styled.div`
   flex-direction: column;
   align-items: center;
   transition: transform 0.3s ease;
+  width: 100%;
+  padding: 10px;  // 추가: 내부 여백을 줘서 호버 시 잘리지 않도록 함
 
   &:hover {
     transform: scale(1.05);
@@ -102,19 +69,23 @@ const ProfileImage = styled.img`
   width: 200px;
   height: 200px;
   border-radius: 50%;
-  transition: transform 0.3s ease;
+  object-fit: cover;
 `;
 
 const UserInfo = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
 `;
 
 const UserName = styled.h2`
-  font-size: 15px;
-  font-weight: 550;
-  margin-top: 20px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-top: 1rem;
   text-align: center;
-  transition: transform 0.3s ease;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;

--- a/src/components/main/Navigation.jsx
+++ b/src/components/main/Navigation.jsx
@@ -75,7 +75,7 @@ const fetchNotifications = async () => {
         </Logo>
 
         <Navbar>
-          <NavItem href="/main">
+          <NavItem href="/mainpage">
             <img src={HomeIcon} alt="Home" />
           </NavItem>
           <NavItem href="/curationart">

--- a/src/pages/Main/MainPage.jsx
+++ b/src/pages/Main/MainPage.jsx
@@ -1,0 +1,177 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { getUsers, getPosts } from '../../utils/api';
+import UserProfileCard from '../../components/UserProfile';
+import PostCard from '../../components/PostCard';
+import { ChevronRight } from 'lucide-react';
+
+const CardSection = ({ title, cards, cardWidth }) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const visibleCards = 4;
+  const cardCount = cards.length;
+
+  const nextCards = () => {
+    setCurrentIndex((prevIndex) => 
+      Math.min(prevIndex + 1, cardCount - visibleCards)
+    );
+  };
+
+  const prevCards = () => {
+    setCurrentIndex((prevIndex) => Math.max(prevIndex - 1, 0));
+  };
+
+  return (
+    <Section>
+      <Header>
+        <Title>{title}</Title>
+        <MoreButton>
+          More <ChevronRight className="w-4 h-4 ml-1" />
+        </MoreButton>
+      </Header>
+      <CardContainer>
+        <PrevButton onClick={prevCards} disabled={currentIndex === 0}>
+          ◀
+        </PrevButton>
+        <CardWrapper currentIndex={currentIndex} visibleCards={visibleCards}>
+          {cards.map((card, index) => (
+            <Card key={index} className={cardWidth}>
+              {card}
+            </Card>
+          ))}
+        </CardWrapper>
+        <NextButton 
+          onClick={nextCards} 
+          disabled={currentIndex >= cardCount - visibleCards}
+        >
+          ▶
+        </NextButton>
+      </CardContainer>
+    </Section>
+  );
+};
+
+const MainPage = () => {
+  const [users, setUsers] = useState([]);
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [fetchedUsers, fetchedPosts] = await Promise.all([
+          getUsers(),
+          getPosts()
+        ]);
+        setUsers(fetchedUsers);
+        setPosts(fetchedPosts);
+      } catch (error) {
+        console.error('Failed to fetch data:', error);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const artistCards = users.map((user) => (
+    <UserProfileCard key={user._id} user={user} />
+  ));
+
+  const postCards = posts.map((post) => (
+    <PostCard 
+      key={post._id} 
+      post={post} 
+      onLikeUpdate={(postId, isLiked, newLikeCount) => {
+        // Handle like update logic here
+      }}
+      onPostDelete={(postId) => {
+        // Handle post delete logic here
+      }}
+    />
+  ));
+
+  return (
+    <PageContainer>
+      <CardSection 
+        title="지금 가장 핫한 아티스트의 음원을 확인해보세요." 
+        cards={artistCards}
+        cardWidth="w-48"
+      />
+      <CardSection 
+        title="사람들이 가장 공감하고 있는 노래는 무엇일까요?" 
+        cards={postCards}
+        cardWidth="w-64"
+      />
+    </PageContainer>
+  );
+};
+
+export default MainPage;
+
+// Styled Components
+const Section = styled.section`
+  margin-bottom: 3rem;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+`;
+
+const Title = styled.h2`
+  font-size: 1.25rem;
+  font-weight: 600;
+`;
+
+const MoreButton = styled.button`
+  display: flex;
+  align-items: center;
+  color: #6b7280;
+  font-size: 0.875rem;
+  &:hover {
+    color: #1f2937;
+  }
+`;
+
+const CardContainer = styled.div`
+  position: relative;
+`;
+
+const PrevButton = styled.button`
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: white;
+  border-radius: 50%;
+  padding: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 10;
+  &:disabled {
+    opacity: 0.5;
+  }
+`;
+
+const NextButton = styled(PrevButton)`
+  left: auto;
+  right: 0;
+`;
+
+const CardWrapper = styled.div`
+  display: flex;
+  transition: transform 0.3s ease-in-out;
+  transform: ${({ currentIndex, visibleCards }) => 
+    `translateX(-${currentIndex * (100 / visibleCards)}%)`};
+  overflow: hidden;
+`;
+
+const Card = styled.div`
+  flex-shrink: 0;
+`;
+
+const PageContainer = styled.div`
+  padding: 1.5rem;
+  background-color: #f3f4f6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+`;

--- a/src/pages/Main/MainPage.jsx
+++ b/src/pages/Main/MainPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import { getUsers, getPosts } from '../../utils/api';
 import UserProfile from '../../components/UserProfile';
 import PostCard from '../../components/PostCard';
@@ -8,7 +9,7 @@ import { ChevronRight, ChevronLeft } from 'lucide-react';
 
 const CardSection = ({ cards, cardWidth, isUserProfile = false }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const visibleCards = isUserProfile ? 5 : 4;  // 유저 프로필 카드는 5개, 다른 카드는 4개
+  const visibleCards = isUserProfile ? 5 : 4;
 
   const nextCards = () => {
     setCurrentIndex((prevIndex) => 
@@ -95,7 +96,7 @@ const MainPage = () => {
         <Underline />
         <CardSection 
           cards={artistCards}
-          cardWidth="w-40"  // 카드 너비를 줄임
+          cardWidth="w-40"
           isUserProfile={true}
         />
       </Section>
@@ -103,7 +104,7 @@ const MainPage = () => {
       <Section>
         <SectionHeader>
           <Title>사람들이 가장 공감하고 있는 노래는 무엇일까요?</Title>
-          <MoreLink>More <ChevronRight className="w-4 h-4 ml-1" /></MoreLink>
+          <MoreLink as={Link} to="/postfeed">More <ChevronRight className="w-4 h-4 ml-1" /></MoreLink>
         </SectionHeader>
         <Underline />
         <CardSection 
@@ -115,7 +116,6 @@ const MainPage = () => {
       <Section>
         <SectionHeader>
           <Title>지금 가장 주목받고 있는 노래들은 무엇일까요?</Title>
-          <MoreLink>More <ChevronRight className="w-4 h-4 ml-1" /></MoreLink>
         </SectionHeader>
         <Underline />
         <AlbumCurationCard />
@@ -126,7 +126,6 @@ const MainPage = () => {
 
 export default MainPage;
 
-// Styled Components
 // Styled Components
 const PageContainer = styled.div`
   padding: 1.5rem;
@@ -158,7 +157,7 @@ const Underline = styled.div`
   margin-bottom: 2rem;
 `;
 
-const MoreLink = styled.a`
+const MoreLink = styled(Link)`
   display: flex;
   align-items: center;
   color: #6b7280;

--- a/src/pages/Main/MainPage.jsx
+++ b/src/pages/Main/MainPage.jsx
@@ -1,18 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { getUsers, getPosts } from '../../utils/api';
-import UserProfileCard from '../../components/UserProfile';
+import UserProfile from '../../components/UserProfile';
 import PostCard from '../../components/PostCard';
-import { ChevronRight } from 'lucide-react';
+import AlbumCurationCard from '../../components/CurationCard';
+import { ChevronRight, ChevronLeft } from 'lucide-react';
 
-const CardSection = ({ title, cards, cardWidth }) => {
+const CardSection = ({ cards, cardWidth, isUserProfile = false }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const visibleCards = 4;
-  const cardCount = cards.length;
+  const visibleCards = isUserProfile ? 5 : 4;  // 유저 프로필 카드는 5개, 다른 카드는 4개
 
   const nextCards = () => {
     setCurrentIndex((prevIndex) => 
-      Math.min(prevIndex + 1, cardCount - visibleCards)
+      Math.min(prevIndex + 1, cards.length - visibleCards)
     );
   };
 
@@ -21,32 +21,26 @@ const CardSection = ({ title, cards, cardWidth }) => {
   };
 
   return (
-    <Section>
-      <Header>
-        <Title>{title}</Title>
-        <MoreButton>
-          More <ChevronRight className="w-4 h-4 ml-1" />
-        </MoreButton>
-      </Header>
+    <CardContainerWrapper isUserProfile={isUserProfile}>
+      <PrevButton onClick={prevCards} disabled={currentIndex === 0}>
+        <ChevronLeft />
+      </PrevButton>
       <CardContainer>
-        <PrevButton onClick={prevCards} disabled={currentIndex === 0}>
-          ◀
-        </PrevButton>
         <CardWrapper currentIndex={currentIndex} visibleCards={visibleCards}>
           {cards.map((card, index) => (
-            <Card key={index} className={cardWidth}>
+            <Card key={index} className={cardWidth} isUserProfile={isUserProfile}>
               {card}
             </Card>
           ))}
         </CardWrapper>
-        <NextButton 
-          onClick={nextCards} 
-          disabled={currentIndex >= cardCount - visibleCards}
-        >
-          ▶
-        </NextButton>
       </CardContainer>
-    </Section>
+      <NextButton 
+        onClick={nextCards} 
+        disabled={currentIndex >= cards.length - visibleCards}
+      >
+        <ChevronRight />
+      </NextButton>
+    </CardContainerWrapper>
   );
 };
 
@@ -61,8 +55,12 @@ const MainPage = () => {
           getUsers(),
           getPosts()
         ]);
-        setUsers(fetchedUsers);
-        setPosts(fetchedPosts);
+        
+        const sortedUsers = fetchedUsers.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+        setUsers(sortedUsers.slice(0, 10));
+
+        const sortedPosts = fetchedPosts.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+        setPosts(sortedPosts.slice(0, 10));
       } catch (error) {
         console.error('Failed to fetch data:', error);
       }
@@ -71,7 +69,7 @@ const MainPage = () => {
   }, []);
 
   const artistCards = users.map((user) => (
-    <UserProfileCard key={user._id} user={user} />
+    <UserProfile key={user._id} user={user} />
   ));
 
   const postCards = posts.map((post) => (
@@ -89,23 +87,37 @@ const MainPage = () => {
 
   return (
     <PageContainer>
-      <CardSection 
-        title="취향이 비슷한 유저가 있을지도 몰라요. 프로필을 눌러 확인해보세요!" 
-        cards={artistCards}
-        cardWidth="w-48"
-      />
-      <CardSection 
-        title="사람들이 가장 공감하고 있는 노래는 무엇일까요?" 
-        cards={postCards}
-        cardWidth="w-64"
-      />
       <Section>
-        <Header>
+        <SectionHeader>
+          <Title>지금 가장 핫한 아티스트의 음원을 확인해보세요.</Title>
+          <MoreLink>More <ChevronRight className="w-4 h-4 ml-1" /></MoreLink>
+        </SectionHeader>
+        <Underline />
+        <CardSection 
+          cards={artistCards}
+          cardWidth="w-40"  // 카드 너비를 줄임
+          isUserProfile={true}
+        />
+      </Section>
+
+      <Section>
+        <SectionHeader>
+          <Title>사람들이 가장 공감하고 있는 노래는 무엇일까요?</Title>
+          <MoreLink>More <ChevronRight className="w-4 h-4 ml-1" /></MoreLink>
+        </SectionHeader>
+        <Underline />
+        <CardSection 
+          cards={postCards}
+          cardWidth="w-64"
+        />
+      </Section>
+
+      <Section>
+        <SectionHeader>
           <Title>지금 가장 주목받고 있는 노래들은 무엇일까요?</Title>
-          <MoreButton>
-            More <ChevronRight className="w-4 h-4 ml-1" />
-          </MoreButton>
-        </Header>
+          <MoreLink>More <ChevronRight className="w-4 h-4 ml-1" /></MoreLink>
+        </SectionHeader>
+        <Underline />
         <AlbumCurationCard />
       </Section>
     </PageContainer>
@@ -115,39 +127,64 @@ const MainPage = () => {
 export default MainPage;
 
 // Styled Components
+// Styled Components
+const PageContainer = styled.div`
+  padding: 1.5rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+`;
+
 const Section = styled.section`
   margin-bottom: 3rem;
 `;
 
-const Header = styled.div`
+const SectionHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 `;
 
 const Title = styled.h2`
   font-size: 1.25rem;
-  font-weight: 600;
+  font-weight: 500;
 `;
 
-const MoreButton = styled.button`
+const Underline = styled.div`
+  width: 35%;
+  height: 2px;
+  background-color: black;
+  margin-bottom: 2rem;
+`;
+
+const MoreLink = styled.a`
   display: flex;
   align-items: center;
   color: #6b7280;
   font-size: 0.875rem;
+  text-decoration: none;
+  cursor: pointer;
+
   &:hover {
-    color: #1f2937;
+    text-decoration: underline;
   }
 `;
 
-const CardContainer = styled.div`
+const CardContainerWrapper = styled.div`
   position: relative;
+  width: 100%;
+  margin-top: ${props => props.isUserProfile ? '4rem' : '1rem'};
+`;
+
+const CardContainer = styled.div`
+  overflow: hidden;
+  width: 100%;
 `;
 
 const PrevButton = styled.button`
   position: absolute;
-  left: 0;
+  left: -40px;
   top: 50%;
   transform: translateY(-50%);
   background-color: white;
@@ -162,7 +199,7 @@ const PrevButton = styled.button`
 
 const NextButton = styled(PrevButton)`
   left: auto;
-  right: 0;
+  right: -40px;
 `;
 
 const CardWrapper = styled.div`
@@ -170,17 +207,11 @@ const CardWrapper = styled.div`
   transition: transform 0.3s ease-in-out;
   transform: ${({ currentIndex, visibleCards }) => 
     `translateX(-${currentIndex * (100 / visibleCards)}%)`};
-  overflow: hidden;
 `;
 
 const Card = styled.div`
-  flex-shrink: 0;
-`;
-
-const PageContainer = styled.div`
-  padding: 1.5rem;
-  background-color: #f3f4f6;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
+  flex: 0 0 ${props => props.isUserProfile ? (100 / 5) : (100 / 4)}%;
+  max-width: ${props => props.isUserProfile ? (100 / 5) : (100 / 4)}%;
+  padding: 0 10px;
+  box-sizing: border-box;
 `;

--- a/src/pages/Main/MainPage.jsx
+++ b/src/pages/Main/MainPage.jsx
@@ -90,7 +90,7 @@ const MainPage = () => {
   return (
     <PageContainer>
       <CardSection 
-        title="지금 가장 핫한 아티스트의 음원을 확인해보세요." 
+        title="취향이 비슷한 유저가 있을지도 몰라요. 프로필을 눌러 확인해보세요!" 
         cards={artistCards}
         cardWidth="w-48"
       />
@@ -99,6 +99,15 @@ const MainPage = () => {
         cards={postCards}
         cardWidth="w-64"
       />
+      <Section>
+        <Header>
+          <Title>지금 가장 주목받고 있는 노래들은 무엇일까요?</Title>
+          <MoreButton>
+            More <ChevronRight className="w-4 h-4 ml-1" />
+          </MoreButton>
+        </Header>
+        <AlbumCurationCard />
+      </Section>
     </PageContainer>
   );
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -323,3 +323,16 @@ export const fetchPostsByAuthor = async (authorId, offset = 0, limit = 10) => {
     throw error; // 에러가 발생하면 throw
   }
 };
+
+// 포스트 목록을 가져오는 API
+export const getPosts = async (offset = 0, limit = 10) => {
+  try {
+    const response = await axios.get('/api/posts', {
+      params: { offset, limit },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching posts:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 컨텐츠 허브 역할을 하는 메인페이지를 구현했습니다

## 📝 구현한 내용
- 메인페이지 레이아웃 구현
- 유저 프로필 리스트 최신순(최근에 생성한 유저순)으로 나열
- 포스트 카드 최신순으로 나열
- 큐레이션 카드 나열
- 카드를 좌우로 넘겨볼 수 있는 기능 구현
- 네비게이션바에 메인페이지 연결
- more에 포스트 피드 연결

## ✅ 체크리스트
- [ ] 이슈 내용 모두 적용
- [ ] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- css와 반응형은 추후 다시 다듬을 예정입니다. 현빈님이 제작중인 큐레이션아티스트 페이지에 맞춰서 다듬을거라 일단 올릴게요
- 유저 프로필 more에 아직 피드 연결 안했어요 현빈님이 큐레이션 아티스트 페이지 올려주시면 연결할게요

## 🔗 연관된 이슈
- close #19 
