### PR TITLE
[Refactor] 아티스트 카드 이미지 부분 수정 및 페이지 글귀 수정

### DIFF
--- a/src/components/ArtistCard.jsx
+++ b/src/components/ArtistCard.jsx
@@ -84,7 +84,6 @@ const ArtistCard = ({
     }
   };
 
-  
   const handlePlayPauseClick = (e) => {
     e.stopPropagation();
     onPlayPause();
@@ -301,10 +300,6 @@ const CardImageWrapper = styled.div`
   height: 300px;
   margin-top: 10px;
 
-  &:hover div {
-    opacity: 1;
-  }
-
   @media all and (min-width: 1024px) and (max-width: 1279px) {
     width: 250px;
     height: 280px;
@@ -327,6 +322,11 @@ const CardImage = styled.img`
   object-fit: cover;
   border-radius: 10px;
   pointer-events: none;
+  transition: filter 0.3s ease;
+
+  ${CardImageWrapper}:hover & {
+    filter: brightness(70%);
+  }
 `;
 
 const PlayPauseButton = styled.div`
@@ -339,7 +339,7 @@ const PlayPauseButton = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: 1;
+  opacity: 0;
   transition: opacity 0.3s ease-in-out;
   cursor: pointer;
 

--- a/src/pages/Curation-Artist/CurationArt.jsx
+++ b/src/pages/Curation-Artist/CurationArt.jsx
@@ -16,7 +16,7 @@ const CurationArt = () => {
   const isDragging = useRef(false);
   const startX = useRef(0);
   const scrollLeft = useRef(0);
-  const scrollDistance = useRef(0); 
+  const scrollDistance = useRef(0);
 
   const channelId = '66fb53f9ed2d3c14a64eb9ea';
   const token = localStorage.getItem('token');
@@ -129,15 +129,15 @@ const CurationArt = () => {
   const handleHintClick = () => {
     setShowHint(false);
   };
-  
+
   if (error) return <ErrorMessage>{error}</ErrorMessage>;
 
   return (
     <PageContainer>
       <Section>
         <SectionTitle>
-          새로운 아티스트들의 멋진 앨범을 <br />
-          확인해 보세요!
+          새로운 아티스트들의 <br />
+          멋진 앨범을 확인해 보세요!
         </SectionTitle>
         <ArtistContainer
           ref={artistContainerRef}
@@ -166,8 +166,7 @@ const CurationArt = () => {
       </Section>
       <Section>
         <SectionTitle>
-          당신의 취향에 맞는 <br />
-          음악을 추천해 드릴게요
+          지금 뜨고 있는 <br />이 음악은 어떠신가요?
         </SectionTitle>
         <CurationCard onClick={handleHintClick}>
           {showHint && (
@@ -303,10 +302,10 @@ const HintMessage = styled.div`
   padding: 10px 20px;
   border-radius: 8px;
   z-index: 11;
-  animation: blink 2s infinite; 
+  animation: blink 2s infinite;
 
   @keyframes blink {
-    0%  {
+    0% {
       opacity: 1;
     }
     100% {


### PR DESCRIPTION
## 🛠️ 구현한 기능
-  아티스트 카드 부분에서 계속 재생버튼이 뜨던 기능 수정하였습니다.
- 큐레이션 섹션에서 직접 추천하는 기능은 삭제하였으므로, 알맞게 글귀 수정하였습니다.

## 📝 구현한 내용
- 아티스트 카드 부분 앨범 이미지에 마우스 가져다대면 재생버튼이 뜨도록 수정
- 큐레이션 섹션 글귀 수정

## ✅ 체크리스트
- [ ] 이슈 내용 모두 적용
- [ ] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 기능 관련 나누고 싶은 내용 or 리뷰 요구사항 작성

## 🔗 연관된 이슈
- close #125
